### PR TITLE
chore: release v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usenagi/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Composition-API ergonomics for vanilla DOM. Bring your own mounter.",
   "main": "./dist/main.umd.js",
   "module": "./dist/main.es.js",


### PR DESCRIPTION
## Summary

Bump `package.json` version to **0.2.0** for npm publish after the reactivity API refactor (#393).

## Test plan

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run lint`

Made with [Cursor](https://cursor.com)