### PR TITLE
chore: release v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usenagi/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Composition-API ergonomics for vanilla DOM. Bring your own mounter.",
   "main": "./dist/main.umd.js",
   "module": "./dist/main.es.js",


### PR DESCRIPTION
## Summary

Bump `package.json` version to **0.3.0** for npm publish after the addon install API (#398).

**Breaking changes** (scheduler / deferred mount): see [v0.3.0 release notes](https://github.com/hayakawasho/nagi/releases/tag/v0.3.0).

## Test plan

- [x] Version bump only (no code changes)

Made with [Cursor](https://cursor.com)