### PR TITLE
docs: align README with 0.3.0 API

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -32,9 +32,9 @@ GSAP、Lenis、IntersectionObserver などを `setup()` で初期化し、`useUn
 // counter.ts
 import { create, signal, useWatch, useDomRef } from "@usenagi/core";
 
-const { component } = create();
+const app = create();
 
-component({
+app.component({
   name: "counter",
   setup() {
     const { refs } = useDomRef<{
@@ -71,13 +71,14 @@ npm i @usenagi/core
 ### First component
 
 ```ts
-import { create, defineComponent, signal, useWatch, useDomRef } from "@usenagi/core";
+import { create, defineComponent, propTypes, signal, useWatch, useDomRef } from "@usenagi/core";
 
 const Greeting = defineComponent({
   name: "greeting",
+  props: propTypes<{ name: string }>(),
   setup(el, props) {
     const { refs } = useDomRef<{ message: HTMLParagraphElement }>();
-    const text = signal((props.name as string) ?? "world");
+    const text = signal(props.name ?? "world");
 
     useWatch(text, (v) => {
       refs.message.textContent = `Hello, ${v}!`;
@@ -117,6 +118,13 @@ app.component(Analytics, { when: idle() })(el);
 ---
 
 ## API
+
+### Component Definition
+
+| API                    | 説明                                                             |
+| ---------------------- | ---------------------------------------------------------------- |
+| `defineComponent(opts)` | 型安全な `ComponentSetup` 定義ヘルパー                          |
+| `propTypes<T>()`       | コンポーネント props の型マーカー（ランタイムコストゼロ）         |
 
 ### Reactivity
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ You are free to implement `[data-component]` scanning, manifests, lazy imports, 
 // counter.ts
 import { create, signal, useWatch, useDomRef } from "@usenagi/core";
 
-const { component } = create();
+const app = create();
 
-component({
+app.component({
   name: "counter",
   setup() {
     const { refs } = useDomRef<{
@@ -71,13 +71,14 @@ npm i @usenagi/core
 ### First component
 
 ```ts
-import { create, defineComponent, signal, useWatch, useDomRef } from "@usenagi/core";
+import { create, defineComponent, propTypes, signal, useWatch, useDomRef } from "@usenagi/core";
 
 const Greeting = defineComponent({
   name: "greeting",
+  props: propTypes<{ name: string }>(),
   setup(el, props) {
     const { refs } = useDomRef<{ message: HTMLParagraphElement }>();
-    const text = signal((props.name as string) ?? "world");
+    const text = signal(props.name ?? "world");
 
     useWatch(text, (v) => {
       refs.message.textContent = `Hello, ${v}!`;
@@ -117,6 +118,13 @@ An example of automatic mounting by combining `[data-component]` scanning, manif
 ---
 
 ## API
+
+### Component Definition
+
+| API                    | Description                                                                 |
+| ---------------------- | --------------------------------------------------------------------------- |
+| `defineComponent(opts)` | Type-safe helper to define a `ComponentSetup` object                       |
+| `propTypes<T>()`       | Type-only marker for declaring component props shape (zero runtime cost)    |
 
 ### Reactivity
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,6 +24,7 @@
       <li><a href="./computed/">computed</a> — useComputed + useWatch</li>
       <li><a href="./parent-child/">parent-child</a> — addChild + withContext</li>
       <li><a href="./lenis-scroll-scene/">lenis-scroll-scene</a> — Lenis + useComputed</li>
+      <li><a href="./recipes/byo-mounter/">byo-mounter</a> — scheduler + cue + data-component scan</li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Update README / README.ja examples: `app.component`, `propTypes`, Component Definition API table
- Add byo-mounter link to examples index

Docs only — **no version bump**, no npm publish.

## Test plan

- [x] Documentation review only

Made with [Cursor](https://cursor.com)