### PR TITLE
chore(deps): update CI workflow dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
## Summary

Combines open Renovate PRs into one CI update:

- `actions/checkout` v4 → v6 ([#403](https://github.com/hayakawasho/nagi/pull/403))
- `actions/setup-node` v4 → v6 ([#404](https://github.com/hayakawasho/nagi/pull/404))
- Node.js 22 → 24 ([#406](https://github.com/hayakawasho/nagi/pull/406))

No changes to `@usenagi/core` package code or published artifacts.

## Test plan

- [ ] CI passes on this PR
- [ ] Close superseded Renovate PRs #403, #404, #406


Made with [Cursor](https://cursor.com)