### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to `@usenagi/core` are documented here. Release notes also a
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.0] - 2026-06-05
+
+### Added
+
+- `useDeferredUnmount(callback)` lifecycle hook — run async work (e.g. exit animations) before a component is removed from the DOM. The callback runs before `useUnmount`, so cleanup hooks execute only after the deferred work completes.
+- `useSlot().removeChild()` now awaits deferred unmount callbacks before running cleanup, enabling parent-driven async teardown of dynamic children.
+- `errorReport` utility for structured lifecycle error reporting.
+
+### Changed
+
+- Child unmount ordering: `removeChild` now runs deferred unmount → splice → synchronous unmount in a safe sequence that handles concurrent removals.
+- Guard against multiple unmount executions on the same component instance.
+- `DomRefCache` refactored for clarity.
+
+### Fixed
+
+- `removeChild` type definition corrected to accept `ComponentContext`.
+- Scheduler addon unmount middleware now returns the `next()` result.
+
+Full change set: [#418](https://github.com/hayakawasho/nagi/pull/418).
+
 ## [0.4.3] - 2026-05-24
 
 ### Changed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usenagi/core",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Composition-API ergonomics for vanilla DOM. Bring your own mounter.",
   "main": "./dist/main.umd.js",
   "module": "./dist/main.es.js",


### PR DESCRIPTION
## Summary

- `@usenagi/core` を `0.5.0` にバージョンアップ
- CHANGELOG に v0.5.0 のエントリを追加
- dist / 型定義ファイルを再ビルド

### v0.5.0 の主な変更

- **新機能**: `useDeferredUnmount` ライフサイクルフック — 退場アニメーションなどの非同期処理をアンマウント前に実行可能
- **改善**: 子コンポーネントのアンマウント順序の安全性向上、並行削除への対応
- **修正**: `removeChild` の型定義、scheduler addon の unmount middleware の戻り値

Full change set: #418

## Test plan

- [x] 全テスト通過 (13 files, 101 tests)
- [x] ビルド成功
- [ ] マージ後 `npm publish` を実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)