### PR TITLE
docs: add useDeferredUnmount to README

### DIFF
--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -18,7 +18,7 @@ WordPress、CMS、Webflow、静的サイトなどに、仮想 DOM やテンプ�
 
 **アニメーションと相性が良い**
 
-GSAP、Lenis、IntersectionObserver などを `setup()` で初期化し、`useUnmount()` でクリーンアップできる。
+GSAP、Lenis、IntersectionObserver などを `setup()` で初期化し、`useUnmount()` でクリーンアップできる。`useDeferredUnmount()` で退場アニメーションなどの非同期処理を unmount の前に挟むこともできる。
 
 **マウント戦略を縛らない**
 
@@ -147,10 +147,11 @@ useWatch(area, (v) => {
 
 ### Lifecycle
 
-| API              | 説明                                        |
-| ---------------- | ------------------------------------------- |
-| `useMount(fn)`   | コンポーネントのマウント完了後に1回実行する |
-| `useUnmount(fn)` | unmount 時に実行する。クリーンアップに使う  |
+| API                        | 説明                                                              |
+| -------------------------- | ----------------------------------------------------------------- |
+| `useMount(fn)`             | コンポーネントのマウント完了後に1回実行する                       |
+| `useUnmount(fn)`           | unmount 時に実行する。クリーンアップに使う                        |
+| `useDeferredUnmount(fn)`   | unmount の前に実行される非同期コールバック。退場アニメーションに使う |
 
 ```ts
 import gsap from 'gsap';
@@ -160,6 +161,21 @@ setup(el) {
   useUnmount(() => tween.kill());
 }
 ```
+
+親が `removeChild` を呼ぶと `useDeferredUnmount` → `useUnmount` の順で実行される。退場アニメーションの完了を待ってからイベントリスナーの解除や DOM の除去を行う、といったフローをコンポーネント内に閉じて書ける。
+
+```ts
+setup(el) {
+  useDeferredUnmount(async () => {
+    el.classList.remove("is-open");
+    await waitForTransition(el);
+  });
+
+  useUnmount(() => el.remove());
+}
+```
+
+→ [examples/deferred-unmount](../../examples/deferred-unmount/main.ts)
 
 ### DOM helpers
 
@@ -266,6 +282,7 @@ import { visible, idle, interaction, media } from "@usenagi/core/addons/cue";
 | [basic-counter](../../examples/basic-counter/)            | 最小の `signal` + `useWatch` 例                     |
 | [computed](../../examples/computed/)                      | `useComputed` による派生値（width × height = area） |
 | [parent-child](../../examples/parent-child/)              | `createContext` + `withContext` + `useSlot`         |
+| [deferred-unmount](../../examples/deferred-unmount/)          | `useDeferredUnmount` による退場アニメーション       |
 | [lenis-scroll-scene](../../examples/lenis-scroll-scene/)  | Lenis + `useComputed` によるスクロール進捗連動      |
 | [byo-mounter recipe](../../examples/recipes/byo-mounter/) | `[data-component]` スキャン + manifest + cue        |
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,8 @@ You can add `setup()`, lifecycle, and reactivity to WordPress, CMS, Webflow, sta
 
 **Compatible with animation**
 
-You can initialize GSAP, Lenis, IntersectionObserver, etc., in `setup()` and clean them up with `useUnmount()`.
+You can initialize libraries such as GSAP, Lenis, and IntersectionObserver in `setup()`, and perform cleanup using `useUnmount()`.
+You can also use `useDeferredUnmount()` to run async work, such as exit animations, before the unmount occurs.
 
 **Does not restrict mounting strategies**
 
@@ -147,10 +148,11 @@ useWatch(area, (v) => {
 
 ### Lifecycle
 
-| API              | Description                          |
-| ---------------- | ------------------------------------ |
-| `useMount(fn)`   | Runs once after the component mounts |
-| `useUnmount(fn)` | Runs on unmount; use for cleanup     |
+| API                        | Description                                                                 |
+| -------------------------- | --------------------------------------------------------------------------- |
+| `useMount(fn)`             | Runs once after the component mounts                                        |
+| `useUnmount(fn)`           | Runs on unmount; use for cleanup                                            |
+| `useDeferredUnmount(fn)`   | Async callback that runs before unmount; use for exit animations            |
 
 ```ts
 import gsap from 'gsap';
@@ -160,6 +162,21 @@ setup(el) {
   useUnmount(() => tween.kill());
 }
 ```
+
+When a parent calls `removeChild`, it executes in the order of `useDeferredUnmount` followed by `useUnmount`. This allows you to encapsulate the flow within the component, such as waiting for an exit animation to complete before removing event listeners or the DOM.
+
+```ts
+setup(el) {
+  useDeferredUnmount(async () => {
+    el.classList.remove("is-open");
+    await waitForTransition(el);
+  });
+
+  useUnmount(() => el.remove());
+}
+```
+
+→ [examples/deferred-unmount](../../examples/deferred-unmount/main.ts)
 
 ### DOM helpers
 
@@ -266,6 +283,7 @@ import { visible, idle, interaction, media } from "@usenagi/core/addons/cue";
 | [basic-counter](../../examples/basic-counter/)            | Minimal `signal` + `useWatch` example                    |
 | [computed](../../examples/computed/)                      | Derived value with `useComputed` (width × height = area) |
 | [parent-child](../../examples/parent-child/)              | `createContext` + `withContext` + `useSlot`              |
+| [deferred-unmount](../../examples/deferred-unmount/)          | Exit animation with `useDeferredUnmount`                  |
 | [lenis-scroll-scene](../../examples/lenis-scroll-scene/)  | Scroll-progress animation with Lenis + `useComputed`     |
 | [byo-mounter recipe](../../examples/recipes/byo-mounter/) | `[data-component]` scanning + manifest + cue             |
 


### PR DESCRIPTION
## Summary

- README (EN/JA) に `useDeferredUnmount` の説明を追加
- 「Why nagi?」のアニメーション訴求に非同期アンマウントを追記
- Lifecycle セクションに API・実行順序の説明・コード例を追加
- Examples テーブルに deferred-unmount を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)