### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to `@usenagi/core` are documented here. Release notes also a
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.7.0] - 2026-07-15
 
 ### Added
 
+- `useEvent` now accepts any `EventTarget` — `window`, `document`, `MediaQueryList`, custom targets — with typed overloads for window / document event maps.
 - Debug info trace — mount / unmount now emit `level: "info"` debug events (`source: "lifecycle"`). Emitted only when a debug reporter is registered; without one the app stays completely silent.
 - `scheduler` addon emits `level: "info"` / `source: "scheduler"` events for cue-deferred mounts: `pending` (cue wait started), `resolved` (cue fulfilled), `aborted` (cancelled by unmount, cue error, or re-registration).
 - `AddonContext.emitDebugEvent(event)` — addons such as `scheduler` can forward defined debug events to the app's reporters. `elementLabel` is derived automatically when only `element` is passed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1958,7 +1958,7 @@
     },
     "packages/core": {
       "name": "@usenagi/core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-core": "^1.14.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usenagi/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Lightweight lifecycle hooks and reactivity for existing HTML.",
   "main": "./dist/main.umd.js",
   "module": "./dist/main.es.js",


### PR DESCRIPTION
## v0.7.0

非破壊の追加リリース。#426(useEvent の EventTarget 対応)+ #427(debug info トレース)を含む。

- CHANGELOG の Unreleased を 0.7.0 に確定(useEvent の EventTarget 対応の記載を追加)
- `@usenagi/core` を 0.6.0 → 0.7.0 に bump

破壊的変更(#428)は次の v0.8.0 で別途リリース。

🤖 Generated with [Claude Code](https://claude.com/claude-code)