### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `@usenagi/core` are documented here. Release notes also a
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.8.0] - 2026-07-15
 
 ### Removed (BREAKING)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1958,7 +1958,7 @@
     },
     "packages/core": {
       "name": "@usenagi/core",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-core": "^1.14.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usenagi/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Lightweight lifecycle hooks and reactivity for existing HTML.",
   "main": "./dist/main.umd.js",
   "module": "./dist/main.es.js",


### PR DESCRIPTION
## v0.8.0

破壊的変更のリリース。#428 を含む。

- core からリアクティビティ全撤去(signals addon に一本化)
- useMediaQuery 削除(useEvent + matchMedia の合成で代替)
- CHANGELOG の Unreleased を 0.8.0 に確定、`@usenagi/core` を 0.7.0 → 0.8.0 に bump

マイグレーション手順は CHANGELOG 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)